### PR TITLE
Don't throw an error on an empty mongoose collection

### DIFF
--- a/lib/mongoose-paginate.js
+++ b/lib/mongoose-paginate.js
@@ -18,11 +18,11 @@ module.exports = function(paginate) {
 			var last = Math.ceil(count / perPage); // 10
 
 			// Clamp the page to positive numbers within the range.
-			if (page < 0) {
-				page = 1;
-			}
 			if (page > last) {
 				page = last;
+			}
+			if (page <= 0) {
+				page = 1;
 			}
 
 			var skip = (page - 1) * perPage;


### PR DESCRIPTION
Hi, I fixed an error when using paginate on a Mongoose collection with no documents.
