### PR TITLE
Allow option for not clamping to last page

### DIFF
--- a/lib/mongoose-paginate.js
+++ b/lib/mongoose-paginate.js
@@ -4,6 +4,8 @@
  */
 
 module.exports = function(paginate) {
+  // options
+  //   clampToLastPage: Boolean, default true - set to false to allow page numbers beyond the last page (they will be empty)
 	return function(options, callback) {
 		var query = this;
 		var model = query.model;
@@ -26,8 +28,11 @@ module.exports = function(paginate) {
 			if (page < 0) {
 				page = 1;
 			}
-			if (page > last) {
-				page = last;
+
+			if (options.clampToLastPage !== false) {
+			  if (page > last) {
+			  	page = last;
+			  }
 			}
 
 			var skip = (page - 1) * perPage;

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -99,6 +99,10 @@ module.exports = function(options) {
 
 		return {
 			pages: pages,
+			// Add pagination summary info
+			count: itemCount,
+			perPage: itemsPerPage,
+			currentPage: currentPage,
 			render: function render(options) {
 				// @TODO: Improve on the template options and add view caching.
 				var template = fs.readFileSync(templates.pagination);

--- a/test/mongoose.js
+++ b/test/mongoose.js
@@ -44,6 +44,29 @@ describe('Paginate', function() {
 		);
 	});
 
+	describe('options', function() {
+    
+    it('should not clamp to the last page if the user sets the correct option', function(done) {
+			Example.find()
+			.sort({ value: 1 })
+			.paginate({ page: 6000, clampToLastPage: false }, function(err, examples) {
+        examples.should.have.length(0);
+
+        done();
+			});
+    });
+
+    it('should clamp to the last page if no option is given', function(done) {
+			Example.find()
+			.sort({ value: 1 })
+			.paginate({ page: 6000 }, function(err, examples) {
+        examples.should.have.length(5);
+
+        done();
+			});
+    });
+  });
+
 	describe('#render', function() {
 
 		it('should return the array of example models with a .pagination property', function(done) {

--- a/test/pages.js
+++ b/test/pages.js
@@ -46,6 +46,10 @@ describe('Paginate', function() {
 			paging.pages[4].should.have.property('page', 10);
 			paging.pages[4].should.have.property('isLast', true);
 
+			paging.should.have.property('count', data.length);
+			paging.should.have.property('perPage', PER_PAGE);
+			paging.currentPage.should.have.property('page', 1);
+
 			done();
 		});
 


### PR DESCRIPTION
Provides an option to not clamp the page to last available page.  Does not change the default behavior.

See issue #5.
